### PR TITLE
Bring back `keep`

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ The list of built project files. This option should be relative to `distDir` and
 
 *Default:* `context.distDir`
 
+### keep
+
+Keep original file and write compressed data to `originalFile.br`
+
+*Default:* `false`
+
 ## Prequisites
 
 The following properties are expected to be present on the deployment `context` object:

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -103,25 +103,54 @@ describe('brotli plugin', function() {
       return rimraf(context.distDir);
     });
 
-    it('adds the br suffix to the distFiles', function(done) {
-      plugin.willUpload(context)
-        .then(function(result) {
-          assert.include(result.distFiles, 'assets/foo.js.br');
-          done();
-        }).catch(function(reason){
-          done(reason);
-        });
+    describe('When the `keep` option is set to true', function() {
+      beforeEach(function() {
+        context.config.brotli.keep = true;
+      });
+
+      it('adds the br suffix to the distFiles', function (done) {
+        plugin.willUpload(context)
+          .then(function (result) {
+            assert.include(result.distFiles, 'assets/foo.js.br');
+            done();
+          }).catch(function (reason) {
+            done(reason);
+          });
+      });
+
+      it('adds the brotli files to the distFiles', function (done) {
+        assert.isFulfilled(plugin.willUpload(context))
+          .then(function (result) {
+            assert.include(result.distFiles, 'assets/foo.js.br');
+            assert.include(result.brotliCompressedFiles, 'assets/foo.js.br')
+            done();
+          }).catch(function (reason) {
+            done(reason);
+          });
+      });
     });
 
-    it('adds the brotli files to the distFiles', function(done) {
-      assert.isFulfilled(plugin.willUpload(context))
-        .then(function(result) {
-          assert.include(result.distFiles, 'assets/foo.js.br');
-          assert.include(result.brotliCompressedFiles, 'assets/foo.js.br')
-          done();
-        }).catch(function(reason){
-          done(reason);
-        });
+    describe('When the `keep` option is left blank or set to true', function() {
+      it('does not the br suffix to the distFiles', function(done) {
+        plugin.willUpload(context)
+          .then(function(result) {
+            assert.include(result.distFiles, 'assets/foo.js');
+            done();
+          }).catch(function(reason){
+            done(reason);
+          });
+      });
+
+      it('adds the brotli files to the distFiles', function(done) {
+        assert.isFulfilled(plugin.willUpload(context))
+          .then(function(result) {
+            assert.include(result.distFiles, 'assets/foo.js');
+            assert.include(result.brotliCompressedFiles, 'assets/foo.js')
+            done();
+          }).catch(function(reason){
+            done(reason);
+          });
+      });
     });
   });
 });


### PR DESCRIPTION
This changes this plugin to make it closer to `ember-cli-deploy-gzip`.

Now it has a `keep` that when false (defaults to false) option to compress files but don't add the `.br` extension at the end, just like `ember-cli-deploy-gzip` has the same option to avoid adding `.gz` to the gzipped files.

This is a breaking change, so I'd release a new major version. 