### PR TITLE
Add keep option to replace original files with compressed files

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ The list of built project files. This option should be relative to `distDir` and
 
 *Default:* `context.distDir`
 
+### keep
+
+Keep original file and write compressed data to `originalFile.br`
+
+*Default:* `false`
+
 ## Prequisites
 
 The following properties are expected to be present on the deployment `context` object:

--- a/index.js
+++ b/index.js
@@ -1,10 +1,14 @@
 /*eslint-env node*/
 'use strict';
 
-var compressStream  = require('iltorb').compressStream;
-var RSVP   = require('rsvp');
-var path      = require('path');
+var fs = require('fs');
+var compressStream = require('iltorb').compressStream;
+var RSVP = require('rsvp');
+var path = require('path');
 var minimatch = require('minimatch');
+
+var denodeify = RSVP.denodeify;
+var renameFile  = denodeify(fs.rename);
 
 var DeployPluginBase = require('ember-cli-deploy-plugin');
 
@@ -19,6 +23,7 @@ module.exports = {
       defaultConfig: {
         filePattern: '**/*.{js,css,json,ico,map,xml,txt,svg,eot,ttf,woff,woff2}',
         ignorePattern: null,
+        keep: false,
         distDir: function(context){
           return context.distDir;
         },
@@ -33,29 +38,35 @@ module.exports = {
         var ignorePattern   = this.readConfig('ignorePattern');
         var distDir         = this.readConfig('distDir');
         var distFiles       = this.readConfig('distFiles') || [];
+        var keep            = this.readConfig('keep');
 
         this.log('Compressing with brotli `' + filePattern + '`', { verbose: true });
         this.log('ignoring `' + ignorePattern + '`', { verbose: true });
-        return this._compressedFiles(distDir, distFiles, filePattern, ignorePattern)
+        return this._compressedFiles(distDir, distFiles, filePattern, ignorePattern, keep)
           .then(function(brotliCompressedFiles) {
             self.log('Compressed with brotli ' + brotliCompressedFiles.length + ' files ok', { verbose: true });
+            if (keep) {
+              self.log('keep is enabled, added brotli-compressed files to `context.distFiles`', { verbose: true });
               return {
                 distFiles: [].concat(brotliCompressedFiles), // needs to be a copy
                 brotliCompressedFiles
               };
+            } else {
+              return { brotliCompressedFiles };
+            }
           })
           .catch(this._errorMessage.bind(this));
       },
-      _compressedFiles: function(distDir, distFiles, filePattern, ignorePattern) {
+      _compressedFiles: function(distDir, distFiles, filePattern, ignorePattern, keep) {
         var filesToCompress = distFiles.filter(minimatch.filter(filePattern, { matchBase: true }));
         if (ignorePattern != null) {
             filesToCompress = filesToCompress.filter(function(path){
               return !minimatch(path, ignorePattern, { matchBase: true });
             });
         }
-        return RSVP.map(filesToCompress, this._compressFile.bind(this, distDir));
+        return RSVP.map(filesToCompress, this._compressFile.bind(this, distDir, keep));
       },
-      _compressFile: function(distDir, filePath) {
+      _compressFile: function(distDir, keep, filePath) {
         var self = this;
         var fullPath = path.join(distDir, filePath);
         var outFilePath = fullPath + '.br';
@@ -76,6 +87,14 @@ module.exports = {
           out.on('finish', function(){
             resolve(filePath + '.br');
           });
+        }).then(function(){
+          if (!keep) {
+            return renameFile(fullPath + '.br', fullPath).then(function () {
+              return filePath;
+            });
+          } else {
+            return filePath + '.br';
+          }
         }).then(function(outFilePath){
           self.log('✔  ' + outFilePath, { verbose: true });
 

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -103,25 +103,35 @@ describe('brotli plugin', function() {
       return rimraf(context.distDir);
     });
 
-    it('adds the br suffix to the distFiles', function(done) {
-      plugin.willUpload(context)
-        .then(function(result) {
-          assert.include(result.distFiles, 'assets/foo.js.br');
-          done();
-        }).catch(function(reason){
-          done(reason);
-        });
+    describe('When the `keep` option is set to true', function() {
+      beforeEach(function() {
+        context.config.brotli.keep = true;
+      });
+
+      it('adds the brotli-compressed files with suffix to `brotliCompressedFiles` and `disfiles` and the uncompressed version to `brotliCompressedFiles` only', function (done) {
+        plugin.willUpload(context)
+          .then(function (result) {
+            assert.include(result.distFiles, 'assets/foo.js.br');
+            assert.include(result.brotliCompressedFiles, 'assets/foo.js.br');
+            assert.notInclude(result.distFiles, 'assets/foo.js');
+            done();
+          }).catch(function (reason) {
+            done(reason);
+          });
+      });
     });
 
-    it('adds the brotli files to the distFiles', function(done) {
-      assert.isFulfilled(plugin.willUpload(context))
-        .then(function(result) {
-          assert.include(result.distFiles, 'assets/foo.js.br');
-          assert.include(result.brotliCompressedFiles, 'assets/foo.js.br')
-          done();
-        }).catch(function(reason){
-          done(reason);
-        });
+    describe('When the `keep` option is left blank or set to false', function() {
+      it('does not the br suffix to the brotliCompressedFiles, and `distFiles` is not present', function(done) {
+        plugin.willUpload(context)
+          .then(function(result) {
+            assert.notOk(result.distFiles, 'distFiles is not present');
+            assert.include(result.brotliCompressedFiles, 'assets/foo.js');
+            done();
+          }).catch(function(reason){
+            done(reason);
+          });
+      });
     });
   });
 });


### PR DESCRIPTION
When this option is disabled, this is a backwards incompatible change, but
for apps supporting internet explorer (most new apps and certainly most apps
wanting to use brotli) its the best default.
Also, this is the same default used by ember-cli-deploy-gzip, which it kind
of brings this addon closer to being a "better replacement" for it.