### PR TITLE
Remove afterInstall hook that added iltorb to package.json

### DIFF
--- a/blueprints/ember-cli-deploy-brotli/index.js
+++ b/blueprints/ember-cli-deploy-brotli/index.js
@@ -1,8 +1,5 @@
 /* eslint-env node */
 module.exports = {
   description: '',
-  normalizeEntityName: function() {},
-  afterInstall: function() {
-     return this.addPackageToProject('iltorb');
-  }
+  normalizeEntityName: function() {}
 };


### PR DESCRIPTION
Removes a function that adds an _iltorb_ dependency to the app's `package.json` 